### PR TITLE
Setting the background color of the tertiary btn

### DIFF
--- a/src/components/Button/index.svelte
+++ b/src/components/Button/index.svelte
@@ -92,6 +92,7 @@
     .tertiary {
         border: 1px solid transparent;
         color: var(--blue);
+        background: initial;
         padding: 0;
         font-weight: var(--font-weight-normal);
         letter-spacing: var(--font-letter-spacing-pos-small);


### PR DESCRIPTION
The background color keep default user agent values, the `background-color: buttonface` initial value change the color. I think the value `initial` may be enough to fix this issue.

Config :
Windows, Chrome Version 80.0.3987.149

Tested with Chrome Incognito

Actual visual :
![image](https://user-images.githubusercontent.com/32040951/78380726-99149180-75d4-11ea-877b-d35d1756ba8d.png)

Visual with `background: initial`
![image](https://user-images.githubusercontent.com/32040951/78381163-4091c400-75d5-11ea-8cc4-18d8f9072f87.png)
