### PR TITLE
Removed console.log(color) from Type component

### DIFF
--- a/src/components/Type/index.svelte
+++ b/src/components/Type/index.svelte
@@ -17,7 +17,6 @@
     });
 
     let cssColorVar = 'var(--' + color + ')';
-    console.log(color);
 
 </script>
 


### PR DESCRIPTION
👋 Hey there,

This project has been an awesome resource for me while working on a couple Figma plugins—so thanks!

But I've found this particular console.log to be really distracting since it fires for every Type component that loads (it pretty much completely fills up the log making it hard to see/find more intentional console.logs.) Just removing it to clean things up a bit.