### PR TITLE
Fix align-self-end property

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -300,6 +300,6 @@ a:focus {
 .align-content-stretch { align-content: stretch; }
 
 .align-self-start { align-self: flex-start; }
-.align-self-end { align-items: flex-end; }
+.align-self-end { align-self: flex-end; }
 .align-self-center { align-self: center; }
 .align-self-stretch { align-self: stretch; }


### PR DESCRIPTION
`align-items` appears to have been mistakenly used as the CSS property for the `.align-self-end` class instead of `align-self`