### PR TITLE
Add value binding to Textarea

### DIFF
--- a/src/components/Textarea/index.svelte
+++ b/src/components/Textarea/index.svelte
@@ -15,6 +15,7 @@
     <textarea 
         type="input"
         on:change
+        bind:value={value}
         {id}
         {name}
         {rows}


### PR DESCRIPTION
This adds component binding of the textarea value. This is specified in the docs, but did not in fact exist in the code.