### PR TITLE
Propose alternative for CSS imports in Vite projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ import { GlobalCSS } from 'figma-plugin-ds-svelte';
 import { Button, Input, SelectMenu } from 'figma-plugin-ds-svelte';
 ```
 
+Alternatively, if your tooling fails to find `GlobalCSS` but supports CSS file imports (e.g. Vite), you can import the global CSS this way:
+
+```javascript
+import 'figma-plugin-ds-svelte/css';
+```
+
 ---
 
 ## Components

--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
   "files": [
     "src"
   ],
+  "exports": {
+    ".": "./src/index.js",
+    "./css": "./src/global.css"
+  },
   "author": "Thomas Lowry",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,14 @@
     "src"
   ],
   "exports": {
-    ".": "./src/index.js",
-    "./css": "./src/global.css"
+    ".": {
+      "default": "./src/index.js",
+      "svelte": "./src/index.js"
+    },
+    "./css": {
+      "default": "./src/global.css",
+      "svelte": "./src/global.css"
+    }
   },
   "author": "Thomas Lowry",
   "license": "MIT",


### PR DESCRIPTION
Hi Tom,

I've been trying to use your library in a [Bolt Svelte plugin](https://github.com/hyperbrew/bolt-figma) and couldn't find a way out of this error when importing the CSS as you documented:

![image](https://github.com/user-attachments/assets/e026d38d-9cb8-4f82-85fb-f6d414bd3bc4)

It seems that the way they've set up Vite, it does not load CSS in external dependencies, and I don't know Svelte well enough to figure out how to address this.

By adding a subpath export to your package, I can however let Vite import and process your global CSS with no effort. If you would please consider merging this PR, it would make my life considerably easier as I'm stuck having to duplicate your CSS file at the moment :sweat_smile: 

Thanks,